### PR TITLE
Develop catalog MOYO

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,9 +1164,9 @@
       "dev": true
     },
     "@mate-academy/scripts": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@mate-academy/scripts/-/scripts-1.2.10.tgz",
-      "integrity": "sha512-BwkVjQfKiybLdpbrILq+bJvJWcROXJtR2CYNl7jACMt/Xrl5dJI3aArMOcX6t/pk+R668BPFaNf7wPRmKeXDLw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@mate-academy/scripts/-/scripts-1.2.12.tgz",
+      "integrity": "sha512-ZXmhAzDKVVDqJmO8soZ7EUYDdWm5BkRL4iV4dKTnpUSrWuv3ch8dUmvXZnXhpE/ptP3JqkAb5lfS8CCCj8Yeng==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^17.11.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "catalog-page",
+  "source": "src/index.html",
   "version": "1.0.0",
   "description": "Frontend practice with catalog page",
   "scripts": {
     "init": "mate-scripts init",
-    "start": "mate-scripts start",
+    "start": "parcel --open",
     "lint": "mate-scripts lint",
     "test:only": "mate-scripts test",
-    "build": "mate-scripts build",
+    "build": "parcel build",
     "deploy": "mate-scripts deploy",
     "update": "mate-scripts update",
     "postinstall": "npm run update",

--- a/readme.md
+++ b/readme.md
@@ -28,14 +28,14 @@ Make all the changes smooth on hover (during 300ms):
 ## Checklist
 
 ❗️ Replace `<your_account>` with your Github username and copy the links to `Pull Request` description:
-- [DEMO LINK](https://<your_account>.github.io/layout_catalog/)
-- [TEST REPORT LINK](https://<your_account>.github.io/layout_catalog/report/html_report/)
+- [DEMO LINK](https://VerJane23.github.io/layout_catalog/)
+- [TEST REPORT LINK](https://VerJane23.github.io/layout_catalog/report/html_report/)
 
 ❗️ Copy this `Checklist` to the `Pull Request` description after links, and put `- [x]` before each point after you checked it.
 
-- [ ] All component follow BEM and use SCSS
-- [ ] repaeted sizes and special colors are put to variables
-- [ ] Grid is used for the columns
-- [ ] cards are shown in 1, 2, 3 or 4 columns based on screen resolution
-- [ ] All changes on `:hover` are smooth
-- [ ] Code follows all the [Code Style Rules ❗️](https://mate-academy.github.io/layout_task-guideline/html-css-code-style-rules)
+- [x] All component follow BEM and use SCSS
+- [x] repaeted sizes and special colors are put to variables
+- [x] Grid is used for the columns
+- [x] cards are shown in 1, 2, 3 or 4 columns based on screen resolution
+- [x] All changes on `:hover` are smooth
+- [x] Code follows all the [Code Style Rules ❗️](https://mate-academy.github.io/layout_task-guideline/html-css-code-style-rules)

--- a/src/index.html
+++ b/src/index.html
@@ -1,12 +1,428 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="page">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Catalog</title>
-    <link rel="stylesheet" href="./styles/main.scss">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./styles/index.scss">
   </head>
-  <body>
-    <h1>Catalog</h1>
+  <body class="page__body">
+    <header class="header">
+      <a href="#" class="header__logo-link">
+        <img
+          src="./images/logo.png"
+          alt="MOYO"
+          class="header__logo"
+        >
+      </a>
+      <nav class="nav">
+        <ul class="nav__list">
+          <li class="nav__item">
+            <a href="#apple" class="nav__link is-active">Apple</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#samsung" class="nav__link">Samsung</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#smartphones" class="nav__link">Smartphones</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#laptops&computers"
+               class="nav__link nav__link--blue"
+               data-qa="nav-hover">Laptops & Computers
+            </a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#gadgets" class="nav__link">Gadgets</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#tablets" class="nav__link">Tablets</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#photo" class="nav__link">Photo</a>
+          </li>
+
+          <li class="nav__item">
+            <a href="#video" class="nav__link">Video</a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="container">
+      <section class="catalog">
+
+        <article class="goodsCard" data-qa="card">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+            data-qa="card-hover"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+        <article class="goodsCard">
+          <img
+            src="./images/imac.jpeg"
+            class="goodsCard__image"
+            alt="imac"
+          >
+          <h2 class="goodsCard__title">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </h2>
+
+          <p class="goodsCard__article">
+            Product code: 195434
+          </p>
+
+          <div class="goodsCard__rating">
+            <div class="stars stars--4">
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+              <div class="stars__star"></div>
+            </div>
+
+            <p class="goodsCard__reviews">
+              Reviews: 5
+            </p>
+          </div>
+
+          <div class="goodsCard__price">
+            <p class="goodsCard__note">
+              Price:
+            </p>
+
+            <p class="goodsCard__value">
+              $2,199
+            </p>
+          </div>
+
+          <a
+            href="#"
+            class="goodsCard__button"
+          >
+          BUY
+          </a>
+        </article>
+      </section>
+    </main>
   </body>
 </html>

--- a/src/styles/blocks/catalog.scss
+++ b/src/styles/blocks/catalog.scss
@@ -1,0 +1,19 @@
+.catalog {
+  display: grid;
+  grid-template-columns: repeat(1, 200px);
+  gap: 46px;
+  column-gap: 48px;
+  justify-content: center;
+
+  @media (min-width: 488px) {
+    grid-template-columns: repeat(2, 200px);
+  }
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, 200px);
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(4, 200px);
+  }
+}

--- a/src/styles/blocks/goodsCard.scss
+++ b/src/styles/blocks/goodsCard.scss
@@ -1,0 +1,86 @@
+.goodsCard {
+  @include goodsCard;
+
+  padding: 0 16px 16px;
+  width: 200px;
+  transition: transform $duration;
+
+  &:hover {
+    transform: scale(1.2);
+  }
+
+  &__image {
+    margin: 32px 3px 0;
+    width: 160px;
+    height: 134px;
+  }
+
+  &__title {
+    width: 166px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 18px;
+    color: $accent-text-color;
+    margin: 40px 0 0;
+  }
+
+  &:hover &__title {
+    color: $title-hover-color;
+  }
+
+  &__article {
+    font-size: 10px;
+    line-height: 14px;
+    color: $basic-text-color;
+    margin: 4px 0 0;
+  }
+
+  &__rating {
+    @include inlineBlock;
+
+    width: 166px;
+    height: 16px;
+    font-size: 10px;
+    line-height: 14px;
+    margin: 16px 0 0;
+  }
+
+  &__price {
+    @include inlineBlock;
+
+    width: 166px;
+    line-height: 18px;
+    margin: 24px 0 0;
+  }
+
+  &__note {
+    margin: 0;
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  &__value {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 18px;
+  }
+
+  &__button {
+    @include cardButton;
+
+    width: 166px;
+    height: 40px;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 16px;
+    margin: 16px 0 0;
+    transition: transform $duration;
+
+    &:hover {
+      background-color: $button-hover-bg-color ;
+      color: $button-hover-text-color;
+    }
+  }
+}

--- a/src/styles/blocks/goodsCard.scss
+++ b/src/styles/blocks/goodsCard.scss
@@ -1,5 +1,5 @@
 .goodsCard {
-  @include goodsCard;
+  @include goods-card;
 
   padding: 0 16px 16px;
   width: 200px;
@@ -37,7 +37,7 @@
   }
 
   &__rating {
-    @include inlineBlock;
+    @include inline-block;
 
     width: 166px;
     height: 16px;
@@ -47,7 +47,7 @@
   }
 
   &__price {
-    @include inlineBlock;
+    @include inline-block;
 
     width: 166px;
     line-height: 18px;
@@ -68,7 +68,7 @@
   }
 
   &__button {
-    @include cardButton;
+    @include card-button;
 
     width: 166px;
     height: 40px;

--- a/src/styles/blocks/header.scss
+++ b/src/styles/blocks/header.scss
@@ -1,0 +1,13 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 50px;
+  background-color: $header-bg-color;
+
+  &__logo {
+    display: block;
+    width: 40px;
+    height: 40px;
+  }
+}

--- a/src/styles/blocks/nav.scss
+++ b/src/styles/blocks/nav.scss
@@ -5,7 +5,6 @@
     justify-content: space-between;
     list-style: none;
     margin: 0;
-
   }
 
   &__item:not(:last-child) {

--- a/src/styles/blocks/nav.scss
+++ b/src/styles/blocks/nav.scss
@@ -1,0 +1,52 @@
+.nav {
+  &__list {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    list-style: none;
+    margin: 0;
+
+  }
+
+  &__item:not(:last-child) {
+    margin-right: 20px;
+  }
+
+  &__link {
+    display: flex;
+    align-items: center;
+    height: 60px;
+    line-height: 60px;
+    color: $accent-text-color;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: uppercase;
+    text-decoration: none;
+
+    &--blue:hover {
+      color: $nav-text-color;
+      transition: color $duration;
+    }
+  }
+
+  .is-active {
+    color: $button-hover-text-color;
+    position: relative;
+
+    &::after {
+      content: "";
+      display: block;
+      position: absolute;
+      background-color: $button-hover-text-color;
+      height: 4px;
+      width: 100%;
+      border-radius: 8px;
+      bottom: 0;
+      left: 0;
+    }
+
+    &:active {
+      color: $button-hover-bg-color;
+    }
+  }
+}

--- a/src/styles/blocks/page.scss
+++ b/src/styles/blocks/page.scss
@@ -1,0 +1,10 @@
+.page {
+  font-family: Roboto, sans-serif;
+
+  &__body {
+    padding: 0;
+    margin: 0;
+    background: lightgray 50%;
+    background-color: $page-bg-color;
+  }
+}

--- a/src/styles/blocks/stars.scss
+++ b/src/styles/blocks/stars.scss
@@ -1,0 +1,24 @@
+.stars {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &__star {
+    height: 16px;
+    width: 16px;
+    margin-right: 4px;
+    background-image: url(../images/star.svg);
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+
+  &__star:last-child {
+    margin-right: 0;
+  }
+
+  @for $n from 1 through 5 {
+    &--#{$n} :nth-child(-n + #{$n}) {
+      background-image: url(../images/star-active.svg);
+    }
+  }
+}

--- a/src/styles/blocks/utils/mixins.scss
+++ b/src/styles/blocks/utils/mixins.scss
@@ -1,0 +1,48 @@
+@mixin on-smartphone {
+  @media ($smartPhone-min-width) {
+    @content;
+  }
+}
+
+@mixin on-tablet {
+  @media ($tablet-min-width) {
+    @content;
+  }
+}
+
+@mixin on-desktop {
+  @media ($desktop-min-width) {
+    @content;
+  }
+}
+
+@mixin goods-card {
+  display: flex;
+  box-sizing: border-box;
+  justify-content: space-between;
+  flex-direction: column;
+  background-color: $card-bg-color;
+  border: 1px solid #f3f3f3;
+  border-radius: 5px;
+}
+
+@mixin inline-block {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+}
+
+@mixin card-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  border: 1px solid $button-bg-color;
+  color: $button-text-color;
+  background-color: $button-bg-color;
+  border-radius: 5px;
+  text-transform: uppercase;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/src/styles/blocks/utils/variables.scss
+++ b/src/styles/blocks/utils/variables.scss
@@ -1,0 +1,17 @@
+$smartphone-min-width: 488px;
+$tablet-min-width: 768px;
+$desktop-min-width: 1024px;
+$star-rank-color: #ffde6a;
+$star-bg-color: #f3f3f3;
+$page-bg-color: #eee8e8;
+$card-bg-color: #fff;
+$button-bg-color: #00acdc;
+$header-bg-color: #fff;
+$button-hover-bg-color: #fff;
+$button-hover-text-color: #00acdc;
+$button-text-color: #fff;
+$basic-text-color: #616070;
+$nav-text-color: #00acdc;
+$title-hover-color: #34568b;
+$accent-text-color: #060b35;
+$duration: 0.3s;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,14 @@
+@import 'blocks/utils/variables';
+@import 'blocks/utils/mixins';
+@import 'blocks/page';
+@import 'blocks/header';
+@import 'blocks/nav';
+@import 'blocks/catalog';
+@import 'blocks/stars';
+@import "blocks/goodsCard";
+
+.container {
+  margin-top: 10px;
+  margin-bottom: 32px;
+  padding: 40px 50px;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}


### PR DESCRIPTION
Considering that NPM and tests do not work correctly, I am sending you with the following comment:
Parcel did not allow (???) to register mixins for tablets and desktop in the catalog file, that’s why you see “media” in the catalog file. In addition, the names of mixins have been corrected at the request of the linter in the kebab case, and spaces between groups of variables have been removed. The horizontal (46) gaps between cards were reduced to the same value - nothing but a simple gap was perceived by the linter. In general, I crammed it in as best I could. 5:3 ✖ Expected shorthand property "gap" declaration-block-no-redundant-longhand-properties
