### PR TITLE
add task solution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Create an HTML page with a catalog. Develop semantic page structure as shown on 
 - add `data-qa="card-hover"` (not just `hover`) to the link `Buy` inside the first card
 - nav links color is not `black` anymore (nav links should have `#060b35` color)
 - add the class `is-active` to the first link (`Apple`) in the navigation
-- use `<main>` tag for cards container 
+- use `<main>` tag for cards container
 - use the grid for cards with different numbers of columns:
   - 1 for the smaller screens
   - 2 starting at `488px`
@@ -33,8 +33,8 @@ This is possible because [we use the Parcel library](https://en.parceljs.org/scs
 ## Checklist
 
 ❗️ Replace `<your_account>` with your GitHub username and copy the links to the `Pull Request` description:
-- [DEMO LINK](https://<your_account>.github.io/layout_catalog/)
-- [TEST REPORT LINK](https://<your_account>.github.io/layout_catalog/report/html_report/)
+- [DEMO LINK](https://diman2807.github.io/layout_catalog/)
+- [TEST REPORT LINK](https://diman2807.github.io/layout_catalog/report/html_report/)
 
 ❗️ Copy this `Checklist` to the `Pull Request` description after links, and put `- [x]` before each point after you checked it.
 

--- a/src/index.html
+++ b/src/index.html
@@ -122,11 +122,11 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
@@ -196,8 +196,8 @@
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button class="catalog__card-btn">Buy</button>
       </article>

--- a/src/index.html
+++ b/src/index.html
@@ -131,8 +131,8 @@
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button
           class="catalog__card-btn"
@@ -157,41 +157,11 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-          </div>
-          <p class="catalog__card-reviews">Reviews: 5</p>
-        </div>
-        <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
-        </div>
-        <button class="catalog__card-btn">Buy</button>
-      </article>
-      <article class="catalog__card">
-        <div class="catalog__card-screen">
-          <img
-            src="./images/imac.jpeg"
-            alt="laptop"
-            class="catalog__card-img"
-          />
-        </div>
-        <div class="catalog__card-descr">
-          <p class="catalog__card-text">
-            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
-          </p>
-          <p class="catalog__card-code">Product code: 195434</p>
-        </div>
-        <div class="catalog__card-evaluation">
-          <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
@@ -217,17 +187,17 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button class="catalog__card-btn">Buy</button>
       </article>
@@ -247,17 +217,17 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button class="catalog__card-btn">Buy</button>
       </article>
@@ -277,17 +247,17 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button class="catalog__card-btn">Buy</button>
       </article>
@@ -307,17 +277,17 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>
         <div class="catalog__card-price">
-          <p>Price:</p>
-          <p>$2,199</p>
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
         </div>
         <button class="catalog__card-btn">Buy</button>
       </article>
@@ -337,11 +307,41 @@
         </div>
         <div class="catalog__card-evaluation">
           <div class="catalog__card-stars">
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
-            <div class="star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p class="catalog__card-price-label">Price:</p>
+          <p class="catalog__card-price-value">$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
+            <div class="catalog__card-star"></div>
           </div>
           <p class="catalog__card-reviews">Reviews: 5</p>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -17,11 +17,340 @@
     />
     <link
       rel="stylesheet"
-      href="styles/index.scss"
+      href="styles/main.scss"
     />
   </head>
 
   <body>
-    <h1>Catalog</h1>
+    <header class="header">
+      <a
+        href="#"
+        class="header__logo"
+      >
+        <img
+          src="./images/logo.png"
+          alt="logo"
+        />
+      </a>
+      <nav class="header__nav">
+        <ul class="header__list">
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link is-active"
+            >
+              Apple
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Samsung
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Smartphones
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+              data-qa="nav-hover"
+            >
+              Laptops & Computers
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Gadgets
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Tablets
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Photo
+            </a>
+          </li>
+          <li class="header__list-item">
+            <a
+              href="#"
+              class="header__link"
+            >
+              Video
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+    <main class="catalog">
+      <article
+        class="catalog__card"
+        data-qa="card"
+      >
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button
+          class="catalog__card-btn"
+          data-qa="card-hover"
+        >
+          Buy
+        </button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+      <article class="catalog__card">
+        <div class="catalog__card-screen">
+          <img
+            src="./images/imac.jpeg"
+            alt="laptop"
+            class="catalog__card-img"
+          />
+        </div>
+        <div class="catalog__card-descr">
+          <p class="catalog__card-text">
+            APPLE A1419 iMac 27" Retina 5K Monoblock (MNED2UA/A)
+          </p>
+          <p class="catalog__card-code">Product code: 195434</p>
+        </div>
+        <div class="catalog__card-evaluation">
+          <div class="catalog__card-stars">
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+            <div class="star"></div>
+          </div>
+          <p class="catalog__card-reviews">Reviews: 5</p>
+        </div>
+        <div class="catalog__card-price">
+          <p>Price:</p>
+          <p>$2,199</p>
+        </div>
+        <button class="catalog__card-btn">Buy</button>
+      </article>
+    </main>
   </body>
 </html>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,0 @@
-body {
-  margin: 0;
-}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,0 +1,246 @@
+* {
+  box-sizing: border-box;
+  font-family: Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+p {
+  margin: 0;
+}
+
+$main-color: #060b35;
+$blue-color: #00acdc;
+$grey-color: #616070;
+
+.header {
+  height: 60px;
+  padding-inline: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: 0.3s;
+
+  &__logo {
+    display: block;
+    width: 40px;
+    height: 40px;
+  }
+
+  &__nav {
+    height: 100%;
+  }
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    display: flex;
+    gap: 20px;
+    height: inherit;
+
+    &-item {
+      display: flex;
+      align-items: center;
+      height: inherit;
+    }
+  }
+
+  &__link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    height: inherit;
+    text-decoration: none;
+    color: $main-color;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+    text-transform: uppercase;
+
+    &:hover {
+      color: $blue-color;
+    }
+
+    &.is-active::after {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 4px;
+      border-radius: 8px;
+      position: absolute;
+      bottom: 0;
+      background-color: $blue-color;
+    }
+  }
+
+  .is-active {
+    color: $blue-color;
+  }
+}
+
+.catalog {
+  padding: 50px 40px 72px;
+  display: grid;
+  grid-template: repeat(2, 1fr) / repeat(4, 1fr);
+  gap: 46px 48px;
+
+  &__card {
+    width: 200px;
+    padding: 32px 16px 16px;
+    border: 1px solid #f3f3f3;
+    background-color: #fff;
+    transition: all 0.3s;
+
+    &-screen {
+      margin-bottom: 40px;
+    }
+
+    &-img {
+      width: 160px;
+      height: 134px;
+      display: block;
+      margin: 0 3px;
+    }
+
+    &-text {
+      color: $main-color;
+      font-size: 12px;
+      font-style: normal;
+      font-weight: 500;
+      line-height: 18px;
+      margin-bottom: 4px;
+    }
+
+    &-descr {
+      margin-bottom: 16px;
+    }
+
+    &-code {
+      color: $grey-color;
+      font-size: 10px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 14px;
+    }
+
+    &-evaluation {
+      display: flex;
+      gap: 17px;
+      align-items: end;
+      margin-bottom: 24px;
+    }
+
+    &-reviews {
+      color: $main-color;
+      text-align: right;
+      font-size: 10px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 14px;
+    }
+
+    &-stars {
+      display: flex;
+
+      .star {
+        width: 16px;
+        height: 16px;
+        background-image: url('../images/star.svg');
+        background-position: center;
+        background-repeat: no-repeat;
+        margin-right: 4px;
+      }
+
+      .star:nth-child(-n + 4) {
+        background-image: url('../images/star-active.svg');
+      }
+    }
+
+    &-price {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 16px;
+
+      p:first-child {
+        color: $grey-color;
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 18px;
+      }
+
+      p:last-child {
+        color: $main-color;
+        text-align: right;
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 18px;
+      }
+    }
+
+    &-btn {
+      width: 100%;
+      height: 40px;
+      border-radius: 5px;
+      background: $blue-color;
+      border: 1px solid $blue-color;
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 16px;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    &:hover {
+      transform: scale(120%);
+      transition: 0.3s;
+
+      .catalog__card-text {
+        color: #34568b;
+      }
+
+      .catalog__card-btn {
+        background-color: #fff;
+        color: $blue-color;
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+@media (min-width: 1200px) {
+  .catalog {
+    padding-inline: 128px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .catalog {
+    grid-template: 1fr / repeat(3, 200px);
+    justify-content: center;
+    gap: 46px 48px;
+    padding-inline: 30px;
+  }
+}
+
+@media (min-width: 488px) and (max-width: 767px) {
+  .catalog {
+    grid-template: 1fr / repeat(2, 200px);
+    gap: 46px 48px;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 320px) and (max-width: 487px) {
+  .catalog {
+    grid-template: 1fr / 200px;
+    gap: 30px;
+    justify-content: center;
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -60,6 +60,7 @@ $grey-color: #616070;
     font-weight: 500;
     line-height: normal;
     text-transform: uppercase;
+    transition: color 0.3s;
 
     &:hover {
       color: $blue-color;
@@ -83,10 +84,10 @@ $grey-color: #616070;
 }
 
 .catalog {
-  padding: 50px 40px 72px;
+  padding: 50px 40px;
   display: grid;
   grid-template: repeat(2, 1fr) / repeat(4, 1fr);
-  gap: 46px 48px;
+  gap: 48px 46px;
 
   &__card {
     width: 200px;
@@ -113,6 +114,7 @@ $grey-color: #616070;
       font-weight: 500;
       line-height: 18px;
       margin-bottom: 4px;
+      transition: color 0.3s;
     }
 
     &-descr {
@@ -146,7 +148,7 @@ $grey-color: #616070;
     &-stars {
       display: flex;
 
-      .star {
+      .catalog__card-star {
         width: 16px;
         height: 16px;
         background-image: url('../images/star.svg');
@@ -155,7 +157,7 @@ $grey-color: #616070;
         margin-right: 4px;
       }
 
-      .star:nth-child(-n + 4) {
+      .catalog__card-star:nth-child(-n + 4) {
         background-image: url('../images/star-active.svg');
       }
     }
@@ -165,7 +167,7 @@ $grey-color: #616070;
       justify-content: space-between;
       margin-bottom: 16px;
 
-      p:first-child {
+      .catalog__card-price-label {
         color: $grey-color;
         font-size: 12px;
         font-style: normal;
@@ -173,7 +175,7 @@ $grey-color: #616070;
         line-height: 18px;
       }
 
-      p:last-child {
+      .catalog__card-price-value {
         color: $main-color;
         text-align: right;
         font-size: 16px;
@@ -195,6 +197,7 @@ $grey-color: #616070;
       line-height: 16px;
       text-transform: uppercase;
       color: #fff;
+      transition: color 0.3s;
     }
 
     &:hover {
@@ -224,7 +227,7 @@ $grey-color: #616070;
   .catalog {
     grid-template: 1fr / repeat(3, 200px);
     justify-content: center;
-    gap: 46px 48px;
+    gap: 48px 46px;
     padding-inline: 30px;
   }
 }
@@ -232,7 +235,7 @@ $grey-color: #616070;
 @media (min-width: 488px) and (max-width: 767px) {
   .catalog {
     grid-template: 1fr / repeat(2, 200px);
-    gap: 46px 48px;
+    gap: 48px 46px;
     justify-content: center;
   }
 }
@@ -240,7 +243,7 @@ $grey-color: #616070;
 @media (min-width: 320px) and (max-width: 487px) {
   .catalog {
     grid-template: 1fr / 200px;
-    gap: 30px;
+    row-gap: 48px;
     justify-content: center;
   }
 }


### PR DESCRIPTION
- [DEMO LINK](https://diman2807.github.io/layout_catalog/)
- [TEST REPORT LINK](https://diman2807.github.io/layout_catalog/report/html_report/)

Create an HTML page with a catalog. Develop semantic page structure as shown on [the mockup](https://www.figma.com/file/ojkArVazq7vsX0nbpn9CxZ/Moyo-%2F-Catalog-(ENG)?node-id=32249%3A354).

- use `Header`, `Stars` and `Card` blocks from previous tasks but rewrite them using BEM and SCSS
- remove old `data-qa` attributes
- add `data-qa="nav-hover"` (not just `hover`) to the 4th nav link for testing (`Laptops & computers`)
- add `data-qa="card"` to the first card
- add `data-qa="card-hover"` (not just `hover`) to the link `Buy` inside the first card
- nav links color is not `black` anymore (nav links should have `#060b35` color)
- add the class `is-active` to the first link (`Apple`) in the navigation
- use `<main>` tag for cards container
- use the grid for cards with different numbers of columns:
  - 1 for the smaller screens
  - 2 starting at `488px`
  - 3 starting from `768px`
  - 4 starting from `1024px`
- cards have fixed width - `200px`
- the gap between cards should be - `46px` horizontally and `48px` vertically
- cards container(catalog) have fixed paddings (`50px` vertically and `40px` horizontally)

Make all the changes smooth on hover (during 300ms):
- increase the card by 20 percent (neighboring cards **should not be** affected)
- change the card title text color to `#34568b` when the card is hovered (`.card:hover .card__title`)
- change navigation link text color to `#00acdc`
- change the button background to `#fff` and text color to `#00acdc` on hover